### PR TITLE
event_types and possible rework for namings

### DIFF
--- a/simplecloud/controller/v1/controller_group_api.proto
+++ b/simplecloud/controller/v1/controller_group_api.proto
@@ -8,7 +8,11 @@ option java_multiple_files = true;
 import "simplecloud/controller/v1/controller_types.proto";
 
 message GetGroupByNameRequest {
-  string name = 1;
+  string group_name = 1;
+}
+
+message DeleteGroupByNameRequest {
+  string group_name = 1;
 }
 
 message GetGroupByNameResponse {
@@ -16,7 +20,7 @@ message GetGroupByNameResponse {
 }
 
 message GetGroupsByTypeRequest {
-  ServerType type = 1;
+  ServerType server_type = 1;
 }
 
 message GetGroupsByTypeResponse {
@@ -31,11 +35,19 @@ message GetAllGroupsResponse {
   repeated GroupDefinition groups = 1;
 }
 
+message CreateGroupRequest {
+  GroupDefinition group = 1;
+}
+
+message UpdateGroupRequest {
+  GroupDefinition group = 1;
+}
+
 service ControllerGroupService {
   rpc GetGroupsByType(GetGroupsByTypeRequest) returns (GetGroupsByTypeResponse);
   rpc GetGroupByName(GetGroupByNameRequest) returns (GetGroupByNameResponse);
-  rpc DeleteGroupByName(GetGroupByNameRequest) returns (GroupDefinition);
-  rpc CreateGroup(GroupDefinition) returns (GroupDefinition);
-  rpc UpdateGroup(GroupDefinition) returns (GroupDefinition);
+  rpc DeleteGroupByName(DeleteGroupByNameRequest) returns (GroupDefinition);
+  rpc CreateGroup(CreateGroupRequest) returns (GroupDefinition);
+  rpc UpdateGroup(UpdateGroupRequest) returns (GroupDefinition);
   rpc GetAllGroups(GetAllGroupsRequest) returns (GetAllGroupsResponse);
 }

--- a/simplecloud/controller/v1/controller_server_api.proto
+++ b/simplecloud/controller/v1/controller_server_api.proto
@@ -6,42 +6,58 @@ option java_package = "app.simplecloud.proto.controller.v1";
 option java_multiple_files = true;
 
 import "simplecloud/controller/v1/controller_types.proto";
+import "simplecloud/controller/v1/event_types.proto";
 
-message GroupNameRequest {
-  string name = 1;
+message GetServersByGroupRequest {
+  string group_name = 1;
 }
 
-message ServerIdRequest {
-  string id = 1;
+message StartServerRequest {
+  string group_name = 1;
+  ServerStartCause start_cause = 2;
+}
+
+message GetServerByIdRequest {
+  string server_id = 1;
+}
+
+message StopServerRequest {
+  string server_id = 1;
+  ServerStopCause cause = 2;
 }
 
 message ServerTypeRequest {
-  ServerType type = 1;
+  ServerType server_type = 1;
 }
 
 message GetServersByGroupResponse {
   repeated ServerDefinition servers = 1;
 }
 
-message ServerUpdatePropertyRequest {
-  string id = 1;
-  string key = 2;
-  string value = 3;
+message GetServersByTypeResponse {
+  repeated ServerDefinition servers = 1;
 }
 
-message ServerUpdateStateRequest {
-  string id = 1;
-  ServerState state = 2;
+message UpdateServerPropertyRequest {
+  string server_id = 1;
+  string property_key = 2;
+  string property_value = 3;
 }
 
-message ServerUpdateRequest {
+message UpdateServerStateRequest {
+  string server_id = 1;
+  ServerState server_state = 2;
+}
+
+message UpdateServerRequest {
   ServerDefinition server = 1;
   bool deleted = 2;
 }
 
 message StopServerByNumericalRequest {
-  string group = 1;
-  uint64 numericalId = 2;
+  string server_group = 1;
+  ServerStopCause stop_cause = 2;
+  uint64 numerical_id = 3;
 }
 
 message GetAllServersRequest {
@@ -53,21 +69,25 @@ message GetAllServersResponse {
 }
 
 message GetServerByNumericalRequest {
-  string group = 1;
-  uint64 numericalId = 2;
+  string group_name = 1;
+  uint64 numerical_id = 2;
+}
+
+message AttachServerHostRequest {
+  ServerHostDefinition server_host = 1;
 }
 
 service ControllerServerService {
   rpc GetAllServers(GetAllServersRequest) returns (GetAllServersResponse);
   rpc GetServersByType(ServerTypeRequest) returns (GetServersByGroupResponse);
-  rpc GetServersByGroup(GroupNameRequest) returns (GetServersByGroupResponse);
+  rpc GetServersByGroup(GetServersByGroupRequest) returns (GetServersByTypeResponse);
   rpc GetServerByNumerical(GetServerByNumericalRequest) returns (ServerDefinition);
-  rpc GetServerById(ServerIdRequest) returns (ServerDefinition);
-  rpc StartServer(GroupNameRequest) returns (ServerDefinition);
-  rpc StopServer(ServerIdRequest) returns (ServerDefinition);
+  rpc GetServerById(GetServerByIdRequest) returns (ServerDefinition);
+  rpc StartServer(StartServerRequest) returns (ServerDefinition);
+  rpc StopServer(StopServerRequest) returns (ServerDefinition);
   rpc StopServerByNumerical(StopServerByNumericalRequest) returns (ServerDefinition);
-  rpc UpdateServer(ServerUpdateRequest) returns (ServerDefinition);
-  rpc UpdateServerState(ServerUpdateStateRequest) returns (ServerDefinition);
-  rpc UpdateServerProperty(ServerUpdatePropertyRequest) returns (ServerDefinition);
-  rpc AttachServerHost(ServerHostDefinition) returns (ServerHostDefinition);
+  rpc UpdateServer(UpdateServerRequest) returns (ServerDefinition);
+  rpc UpdateServerState(UpdateServerStateRequest) returns (ServerDefinition);
+  rpc UpdateServerProperty(UpdateServerPropertyRequest) returns (ServerDefinition);
+  rpc AttachServerHost(AttachServerHostRequest) returns (ServerHostDefinition);
 }

--- a/simplecloud/controller/v1/controller_types.proto
+++ b/simplecloud/controller/v1/controller_types.proto
@@ -5,6 +5,8 @@ package simplecloud.controller.v1;
 option java_package = "app.simplecloud.proto.controller.v1";
 option java_multiple_files = true;
 
+import "google/protobuf/timestamp.proto";
+
 message GroupDefinition {
   string name = 1;
   ServerType type = 2;
@@ -14,44 +16,45 @@ message GroupDefinition {
   uint64 minimum_online_count = 6;
   uint64 maximum_online_count = 7;
   uint64 max_players = 8;
-  map<string, string> properties = 9;
+  map<string, string> cloud_properties = 9;
   uint64 new_server_player_ratio = 10;
 }
 
 message ServerDefinition {
   string unique_id = 1;
-  ServerType type = 2;
+  ServerType server_type = 2;
   string group_name = 3;
   string host_id = 4;
   uint32 numerical_id = 5;
-  string ip = 7;
-  uint64 port = 8;
+  string server_ip = 7;
+  uint64 server_port = 8;
   uint64 minimum_memory = 9;
   uint64 maximum_memory = 10;
   uint64 max_players = 11;
   uint64 player_count = 12;
-  map<string, string> properties = 13;
-  ServerState state = 14;
-  string created_at = 15;
-  string updated_at = 16;
+  map<string, string> cloud_properties = 13;
+  ServerState server_state = 14;
+  google.protobuf.Timestamp created_at = 15;
+  google.protobuf.Timestamp updated_at = 16;
 }
 
 message ServerHostDefinition {
-  string unique_id = 1;
-  string host = 2;
-  uint32 port = 3;
+  string host_id = 1;
+  string host_host = 2;
+  uint32 host_port = 3;
 }
 
 enum ServerState {
-  PREPARING = 0;
-  STARTING = 1;
-  AVAILABLE = 2;
-  INGAME = 3;
-  STOPPING = 4;
+  UNKNOWN_STATE = 0;
+  PREPARING = 1;
+  STARTING = 2;
+  AVAILABLE = 3;
+  INGAME = 4;
+  STOPPING = 5;
 }
 
 enum ServerType {
-  SERVER = 0;
-  PROXY = 1;
-  OTHER = 2;
+  UNKNOWN_SERVER = 0;
+  SERVER = 1;
+  PROXY = 2;
 }

--- a/simplecloud/controller/v1/event_types.proto
+++ b/simplecloud/controller/v1/event_types.proto
@@ -6,16 +6,17 @@ option java_package = "app.simplecloud.proto.controller.v1";
 option java_multiple_files = true;
 
 import "simplecloud/controller/v1/controller_types.proto";
+import "google/protobuf/timestamp.proto";
 
 message GenericEvent {
-  string type = 1; //The event type (PLEASE REVIEW IF THIS IS REALLY NEEDED)
+  string event_type = 1; //Can be any string provided by the user, just for telling apart different events
   bytes data = 2; //This allows for sending any data via events
 }
 
 message ServerStartEvent {
   ServerDefinition server = 1;
-  ServerStartCause cause = 2;
-  string started_at = 3;
+  ServerStartCause start_cause = 2;
+  google.protobuf.Timestamp started_at = 3;
 }
 
 enum ServerStartCause {
@@ -27,9 +28,9 @@ enum ServerStartCause {
 
 message ServerStopEvent {
   ServerDefinition server = 1;
-  ServerStopCause cause = 2;
+  ServerStopCause stop_cause = 2;
   ServerTerminationMode termination_mode = 3;
-  string stopped_at = 4;
+  google.protobuf.Timestamp stopped_at = 4;
 }
 
 //This allows for better filtering: e.g. notify module only showing forced stops in chat
@@ -52,5 +53,5 @@ enum ServerStopCause {
 message ServerUpdateEvent {
   ServerDefinition server_before = 1; //The server definition before the update
   ServerDefinition server_after = 2; //The server definition after the update
-  string updated_at = 3;
+  google.protobuf.Timestamp updated_at = 3;
 }

--- a/simplecloud/controller/v1/server_host_api.proto
+++ b/simplecloud/controller/v1/server_host_api.proto
@@ -6,7 +6,6 @@ option java_package = "app.simplecloud.proto.controller.v1";
 option java_multiple_files = true;
 
 import "simplecloud/controller/v1/controller_types.proto";
-import "simplecloud/controller/v1/controller_server_api.proto";
 
 message StartServerRequest {
   GroupDefinition group = 1;


### PR DESCRIPTION

### TODO - rework namings:

As we have already noticed, all of our namings don't really match the protobuf conventions.
Maybe we can rework our namings too, so we dont have to change the api two times.

### Changes Introduced:
- Added Protobuf definitions for handling server events in the `simplecloud.controller.v1` package.
- Includes the following event messages:
  - `GenericEvent`: A generic event with optional type and data fields.
  - `ServerStartEvent`: Captures information when a server starts, including the server definition, cause, and start time.
  - `ServerStopEvent`: Captures details of a server stopping, including the server definition, stop cause, termination mode, and stop time.
  - `ServerUpdateEvent`: Captures information about a server update, including the before and after server definitions and update timestamp.

#### New Enums:
- **ServerStartCause**: Describes the cause of a server start:
  - `UNKNOWN_START`
  - `RECONCILER_START`
  - `USER_START`
  - `API_START`
  
- **ServerStopCause**: Describes the cause of a server stop:
  - `UNKNOWN_STOP`
  - `RECONCILE_STOP`
  - `USER_STOP`
  - `API_STOP`
  - `TIMEOUT_STOP`
  - `NATURAL_STOP`

- **ServerTerminationMode**: Describes the server termination mode:
  - `UNKNOWN_MODE`
  - `GRACEFUL`
  - `FORCED`

#### Notes for Review:
- Review the necessity of the `type` field in `GenericEvent` to confirm if it is required. Currently, its need is unclear.

